### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules
+npm-debug.log
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# IDE and editor files
+.idea
+.vscode
+.DS_Store
+
+# Build output
+build
+
+# Docker files
+Dockerfile
+.dockerignore
+
+# Misc
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY . .
+RUN npm ci 
+RUN npm run build
+CMD ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ For development with auto-rebuild:
 npm run watch
 ```
 
+### Docker
+
+```bash
+npm run image:build
+```
+
 ## Installation
 
 ### Prerequisites
@@ -73,6 +79,29 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 }
 ```
 
+#### Docker
+
+```json
+{
+  "mcpServers": {
+    "gyazo-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GYAZO_ACCESS_TOKEN",
+        "gyazo-mcp-server"
+      ],
+      "env": {
+        "GYAZO_ACCESS_TOKEN": "your-access-token-here"
+      }
+    }
+  }
+}
+```
+
 ### Debugging
 
 Since MCP servers communicate over stdio, debugging can be challenging. We recommend using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), which is available as a package script:
@@ -88,4 +117,3 @@ The Inspector will provide a URL to access debugging tools in your browser.
 <a href="https://glama.ai/mcp/servers/bhrk879agk">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/bhrk879agk/badge" />
 </a>
-

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build": "npx -y tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "image:build": "docker build -t gyazo-mcp-server .",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",


### PR DESCRIPTION
This PR adds Dockerfile to allow hosting the MCP Server as a Docker container.
Providing a Docker image makes it easy to use from MCP Hosts such as Claude Desktop.